### PR TITLE
run.sh: removal of C++ standard instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ source /cvmfs/sft.cern.ch/lcg/views/LCG_95/x86_64-slc6-gcc8-opt/setup.sh
 The skimming reduces the inital dataset to only the events needed for the analysis. This part is written in C++ in the file `skim.cxx`. To compile and run the program, use the following commands.
 
 ```bash
-g++ -g -std=c++11 -O3 -Wall -Wextra -Wpedantic -o skim skim.cxx $(root-config --cflags --libs)
+g++ -g -O3 -Wall -Wextra -Wpedantic -o skim skim.cxx $(root-config --cflags --libs)
 ./skim
 ```
 

--- a/reana.yaml
+++ b/reana.yaml
@@ -11,7 +11,7 @@ workflow:
       - name: compiling
         environment: reanahub/reana-env-root6:6.18.04
         commands:
-          - g++ -g -std=c++11 -O3 -Wall -Wextra -Wpedantic -o skim skim.cxx `root-config --cflags --libs`
+          - g++ -g -O3 -Wall -Wextra -Wpedantic -o skim skim.cxx `root-config --cflags --libs`
       - name: skimming
         environment: reanahub/reana-env-root6:6.18.04
         commands:

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Build and run skimming
-g++ -g -std=c++11 -O3 -Wall -Wextra -Wpedantic -o skim skim.cxx $(root-config --cflags --libs)
+g++ -g -O3 -Wall -Wextra -Wpedantic -o skim skim.cxx $(root-config --cflags --libs)
 time ./skim
 
 # Produce histograms for plotting


### PR DESCRIPTION
* Removes in the compilation instructions the C++ standard since this
  flag is already included in the output of `root-config --cflags`,
  following cernopendata/opendata.cern.ch#2824.

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>